### PR TITLE
Create the Goctopus connector library and adapt Kafka as one of the connectors

### DIFF
--- a/cmd/kafkaconsumer/kafkaconsumer.go
+++ b/cmd/kafkaconsumer/kafkaconsumer.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/stupendous-man/goctupus/connectors"
+	"os"
+	"log"
+)
+
+func main() {
+	conn := connectors.KafkaConnector{KafkaURL: os.Getenv("KAFKA_PORT_9092_TCP_ADDR") + ":" + os.Getenv("KAFKA_PORT_9092_TCP_PORT"), KafkaTopic: "topic"}
+	msg := conn.Receive()
+	log.Println(msg)
+}

--- a/cmd/kafkaproducer/kafkaproducer.go
+++ b/cmd/kafkaproducer/kafkaproducer.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/stupendous-man/goctupus/connectors"
+	"os"
+)
+
+func main() {
+
+	conn := connectors.KafkaConnector{KafkaURL: os.Getenv("KAFKA_PORT_9092_TCP_ADDR") + ":" + os.Getenv("KAFKA_PORT_9092_TCP_PORT"), KafkaTopic: "topic"}
+	conn.Send("Test Message")
+}

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,0 +1,6 @@
+# Goctopus connectors
+
+Package connectors is a pure Go client library for interfacing with various messaging systems with a focus on simplicity. A high level API is provided through the `Connector` struct. Several implementations will be provided:
+
+* Apache Kafka
+* HTTP REST

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -1,0 +1,10 @@
+package connectors
+
+type Connector interface {
+	send(request RequestMessage)
+	receive() ResponseMessage
+}
+
+type RequestMessage string
+
+type ResponseMessage string

--- a/connectors/kafka.go
+++ b/connectors/kafka.go
@@ -1,0 +1,1 @@
+package connectors

--- a/connectors/kafka.go
+++ b/connectors/kafka.go
@@ -7,11 +7,11 @@ import (
 )
 
 type KafkaConnector struct {
-	kafkaURL   string
-	kafkaTopic string
+	KafkaURL   string
+	KafkaTopic string
 }
 
-func (kc *KafkaConnector) send(request RequestMessage) {
+func (kc *KafkaConnector) Send(request RequestMessage) {
 
 	producer, err := sarama.NewAsyncProducer([]string{kc.kafkaURL}, nil)
 
@@ -38,7 +38,7 @@ func (kc *KafkaConnector) send(request RequestMessage) {
 	producer.Input() <- msg
 }
 
-func (kc *KafkaConnector) receive() ResponseMessage {
+func (kc *KafkaConnector) Receive() ResponseMessage {
 
 	consumer, err := sarama.NewConsumer([]string{kc.kafkaURL}, nil)
 	if err != nil {

--- a/connectors/kafka.go
+++ b/connectors/kafka.go
@@ -1,1 +1,80 @@
 package connectors
+
+import (
+	"github.com/Shopify/sarama"
+	"log" // TODO: use logrus
+	"time"
+)
+
+type KafkaConnector struct {
+	kafkaURL   string
+	kafkaTopic string
+}
+
+func (kc *KafkaConnector) send(request RequestMessage) {
+
+	producer, err := sarama.NewAsyncProducer([]string{kc.kafkaURL}, nil)
+
+	if err != nil {
+		//Retry a few times before going into panic
+		for retries := 1; retries <= 5; retries++ {
+			producer, err = sarama.NewAsyncProducer([]string{kc.kafkaURL}, nil)
+
+			if err != nil {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+
+	//Deferred function to close producer
+	defer func() {
+		producer.AsyncClose()
+	}()
+
+	// send  a message synchronously when send method is called
+	msg := &sarama.ProducerMessage{Topic: kc.kafkaTopic, Value: sarama.StringEncoder(request)}
+	producer.Input() <- msg
+}
+
+func (kc *KafkaConnector) receive() ResponseMessage {
+
+	consumer, err := sarama.NewConsumer([]string{kc.kafkaURL}, nil)
+	if err != nil {
+		//Retry a few times before going into panic
+		for retries := 1; retries <= 5; retries++ {
+			consumer, err = sarama.NewConsumer([]string{kc.kafkaURL}, nil)
+
+			if err != nil {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+
+	//Deferred function to close consumer
+	defer func() {
+		if err := consumer.Close(); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	partitionConsumer, err := consumer.ConsumePartition(kc.kafkaTopic, 0, sarama.OffsetNewest)
+	if err != nil {
+		panic(err)
+	}
+
+	//Deferred function to close partition consumer
+	defer func() {
+		if err := partitionConsumer.Close(); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	// receive one message synchronously on each receive call of the KafkaConnector
+	msg := <-partitionConsumer.Messages()
+
+	return string(msg.Value())
+}

--- a/connectors/kafka.go
+++ b/connectors/kafka.go
@@ -13,12 +13,12 @@ type KafkaConnector struct {
 
 func (kc *KafkaConnector) Send(request RequestMessage) {
 
-	producer, err := sarama.NewAsyncProducer([]string{kc.kafkaURL}, nil)
+	producer, err := sarama.NewAsyncProducer([]string{kc.KafkaURL}, nil)
 
 	if err != nil {
 		//Retry a few times before going into panic
 		for retries := 1; retries <= 5; retries++ {
-			producer, err = sarama.NewAsyncProducer([]string{kc.kafkaURL}, nil)
+			producer, err = sarama.NewAsyncProducer([]string{kc.KafkaURL}, nil)
 
 			if err != nil {
 				time.Sleep(100 * time.Millisecond)
@@ -34,17 +34,17 @@ func (kc *KafkaConnector) Send(request RequestMessage) {
 	}()
 
 	// send  a message synchronously when send method is called
-	msg := &sarama.ProducerMessage{Topic: kc.kafkaTopic, Value: sarama.StringEncoder(request)}
+	msg := &sarama.ProducerMessage{Topic: kc.KafkaTopic, Value: sarama.StringEncoder(request)}
 	producer.Input() <- msg
 }
 
 func (kc *KafkaConnector) Receive() ResponseMessage {
 
-	consumer, err := sarama.NewConsumer([]string{kc.kafkaURL}, nil)
+	consumer, err := sarama.NewConsumer([]string{kc.KafkaURL}, nil)
 	if err != nil {
 		//Retry a few times before going into panic
 		for retries := 1; retries <= 5; retries++ {
-			consumer, err = sarama.NewConsumer([]string{kc.kafkaURL}, nil)
+			consumer, err = sarama.NewConsumer([]string{kc.KafkaURL}, nil)
 
 			if err != nil {
 				time.Sleep(100 * time.Millisecond)
@@ -61,7 +61,7 @@ func (kc *KafkaConnector) Receive() ResponseMessage {
 		}
 	}()
 
-	partitionConsumer, err := consumer.ConsumePartition(kc.kafkaTopic, 0, sarama.OffsetNewest)
+	partitionConsumer, err := consumer.ConsumePartition(kc.KafkaTopic, 0, sarama.OffsetNewest)
 	if err != nil {
 		panic(err)
 	}
@@ -76,5 +76,5 @@ func (kc *KafkaConnector) Receive() ResponseMessage {
 	// receive one message synchronously on each receive call of the KafkaConnector
 	msg := <-partitionConsumer.Messages()
 
-	return string(msg.Value())
+	return ResponseMessage(string(msg.Value))
 }

--- a/connectors/rest.go
+++ b/connectors/rest.go
@@ -1,0 +1,1 @@
+package connectors


### PR DESCRIPTION
As per [this article](https://medium.com/@benbjohnson/structuring-applications-in-go-3b04be4ff091#.rfxpeh64b), binaries should be separated from a library.
This PR is intended to create a generic to Goctopus`Connector` interface and implement the Kafka  case. More connectors will be developed, i.e. Rest